### PR TITLE
Fix tuple example select option

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import rb_hello from './examples/hello.rb?raw';
 import rb_explicit from './examples/explicit.rb?raw';
 import rb_union from './examples/union.rb?raw';
 import rb_array from './examples/array.rb?raw';
-import rb_tuple from './examples/array.rb?raw';
+import rb_tuple from './examples/tuple.rb?raw';
 import rbs_interface from './examples/interface.rbs?raw';
 import rb_interface from './examples/interface.rb?raw';
 


### PR DESCRIPTION
The tuple example is the same as the array.

---

Although not directly related to this PR, I thought it would be useful to have the following link in the About section of the repository or in the README.

https://mame.github.io/typeprof.wasm/
