### PR TITLE
Add Playwright E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,25 @@
+name: E2E
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+      - name: Run E2E tests
+        run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ vscode-rbs-syntax
 wasm-build/build
 wasm-build/rubies
 wasm-build/ruby.wasm
+
+# Playwright
+test-results

--- a/README.md
+++ b/README.md
@@ -33,3 +33,17 @@ $ npm run dev
 ```
 $ npm run build
 ```
+
+## How to run E2E tests
+
+The end-to-end tests build the production bundle, serve it locally, and drive a
+real browser to verify that ruby.wasm boots and TypeProf reports type errors.
+
+```
+$ npm install
+$ npx playwright install chromium
+$ npm run test:e2e
+```
+
+The tests use the committed `public/ruby.wasm`, so no preview/dev setup is
+required. They also run on CI via `.github/workflows/e2e.yml`.

--- a/e2e/playground.spec.ts
+++ b/e2e/playground.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// Navigate (via about:blank so a hash-only change still reloads) and wait for boot.
+const open = async (page: Page, hash = '') => {
+  await page.goto('about:blank');
+  await page.goto(`/${hash}`);
+  await expect(page.locator('#main')).toHaveClass(/ready/, { timeout: 90_000 });
+};
+
+const errorMarkers = (page: Page) => page.locator('.squiggly-error');
+
+const sharedState = (rb: string, rbs: string) => `#${new URLSearchParams({ rb, rbs })}`;
+
+test.describe('TypeProf.wasm playground', () => {
+  test('boots and reports type errors in the default example', async ({ page }) => {
+    const crashes: string[] = [];
+    page.on('pageerror', (e) => crashes.push(e.message));
+
+    await open(page);
+
+    await expect(errorMarkers(page).first()).toBeVisible();
+    expect(crashes).toEqual([]);
+  });
+
+  test('re-analyzes when the example changes', async ({ page }) => {
+    await open(page);
+    await expect(errorMarkers(page).first()).toBeVisible();
+
+    await page.selectOption('#select-example', 'array');
+    await expect(errorMarkers(page)).toHaveCount(0);
+
+    await page.selectOption('#select-example', 'union');
+    await expect(errorMarkers(page).first()).toBeVisible();
+  });
+
+  test('uses the RBS definitions when analyzing Ruby', async ({ page }) => {
+    const ruby = 'user = User.new("Alice")\nuser.name\n';
+    const rbsWithName = 'class User\n  def initialize: (String) -> void\n  def name: -> String\nend\n';
+    const rbsWithoutName = 'class User\n  def initialize: (String) -> void\nend\n';
+
+    await open(page, sharedState(ruby, rbsWithName));
+    await expect(errorMarkers(page)).toHaveCount(0);
+
+    await open(page, sharedState(ruby, rbsWithoutName));
+    await expect(errorMarkers(page).first()).toBeVisible();
+  });
+
+  test('loads every built-in example without crashing', async ({ page }) => {
+    const crashes: string[] = [];
+    page.on('pageerror', (e) => crashes.push(e.message));
+
+    await open(page);
+    const names = await page
+      .locator('#select-example option')
+      .evaluateAll((options) => options.map((o) => (o as HTMLOptionElement).value));
+
+    for (const name of names) {
+      await page.selectOption('#select-example', name);
+      await page.waitForTimeout(2_000);
+      await expect(page.locator('#main')).toHaveClass(/ready/);
+      await expect(page.locator('#error')).not.toHaveClass(/active/);
+    }
+
+    expect(crashes).toEqual([]);
+  });
+
+  test('restores rb and rbs shared via the URL hash', async ({ page }) => {
+    await open(page, sharedState('shared_rb = 1 + "boom"\n', '# shared_rbs\n'));
+
+    await expect(page.locator('#rb-editor')).toContainText('shared_rb');
+    await expect(page.locator('#rbs-editor')).toContainText('shared_rbs');
+    await expect(errorMarkers(page).first()).toBeVisible();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,8 @@
       },
       "devDependencies": {
         "@codingame/esbuild-import-meta-url-plugin": "~1.0.2",
+        "@playwright/test": "^1.60.0",
+        "@types/node": "^22.19.20",
         "@types/vscode": "~1.95.0",
         "typescript": "~5.7.2",
         "vite": "~6.0.3",
@@ -999,6 +1001,22 @@
         "tslib": "2"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
@@ -1028,7 +1046,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -1041,7 +1058,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -1054,7 +1070,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -1067,7 +1082,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -1080,7 +1094,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -1093,7 +1106,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -1106,7 +1118,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1119,7 +1130,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1132,7 +1142,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1145,7 +1154,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1158,7 +1166,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1171,7 +1178,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1184,7 +1190,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1197,7 +1202,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1210,7 +1214,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1223,7 +1226,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1236,7 +1238,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1249,7 +1250,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1262,7 +1262,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1291,14 +1290,13 @@
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
     },
     "node_modules/@types/node": {
-      "version": "22.10.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
-      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "dev": true,
-      "optional": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/vscode": {
@@ -1389,7 +1387,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -2199,6 +2196,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.49",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
@@ -2332,12 +2376,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "6.0.4",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,13 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite --config vite.config.prod build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
   },
   "devDependencies": {
     "@codingame/esbuild-import-meta-url-plugin": "~1.0.2",
+    "@playwright/test": "^1.60.0",
+    "@types/node": "^22.19.20",
     "@types/vscode": "~1.95.0",
     "typescript": "~5.7.2",
     "vite": "~6.0.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "@playwright/test";
+
+const port = 4173;
+const baseURL = `http://127.0.0.1:${port}`;
+
+// vite.config.prod hardcodes `base` to the GitHub Pages URL; override it to `/` for local serving.
+const command = `npm run build -- --base=/ && npx vite preview --config vite.config.prod --base / --host 127.0.0.1 --port ${port}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 120_000,
+  expect: {
+    timeout: 60_000,
+  },
+  workers: 1,
+  use: {
+    baseURL,
+  },
+  webServer: {
+    command,
+    url: baseURL,
+    timeout: 180_000,
+    reuseExistingServer: !process.env.CI,
+  },
+});


### PR DESCRIPTION
Adds Playwright E2E tests as a safety net for upcoming changes (building `ruby.wasm` in CI, auto-updating TypeProf).

The tests verify:
- TypeProf boots and reports type errors in the default example
- editing re-runs the analysis
- RBS definitions affect the Ruby analysis
- every built-in example loads without crashing
- rb/rbs shared via the URL hash are restored